### PR TITLE
feat: dark theme for the dashboard UI

### DIFF
--- a/internal/dashboard/views/dashboard.templ
+++ b/internal/dashboard/views/dashboard.templ
@@ -10,16 +10,16 @@ templ Dashboard(cards []ServiceCard, loc *time.Location) {
 		<div class="space-y-8">
 			<header class="flex items-baseline justify-between">
 				<div class="flex items-baseline">
-					<h1 class="text-3xl font-bold text-gray-900">Golden Gate</h1>
-					<a href="/dashboard/config" class="text-sm text-gray-600 hover:text-gray-900 ml-4">⚙ Editar config</a>
+					<h1 class="text-3xl font-bold text-white">Golden Gate</h1>
+					<a href="/dashboard/config" class="text-sm text-gray-400 hover:text-gray-200 ml-4">⚙ Editar config</a>
 				</div>
-				<span class="text-sm text-gray-500">{ fmt.Sprintf("TZ: %s", loc.String()) }</span>
+				<span class="text-sm text-gray-400">{ fmt.Sprintf("TZ: %s", loc.String()) }</span>
 			</header>
 
 			<section class="space-y-4">
-				<h2 class="text-xl font-semibold text-gray-800">Servicios configurados</h2>
+				<h2 class="text-xl font-semibold text-gray-200">Servicios configurados</h2>
 				if len(cards) == 0 {
-					<p class="text-gray-500">No hay servicios configurados. Editá <code>configs/service.json</code> para agregar uno.</p>
+					<p class="text-gray-400">No hay servicios configurados. Editá <code class="bg-gray-800 px-1.5 py-0.5 rounded text-gray-300">configs/service.json</code> para agregar uno.</p>
 				} else {
 					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
 						for _, c := range cards {
@@ -33,25 +33,25 @@ templ Dashboard(cards []ServiceCard, loc *time.Location) {
 }
 
 templ serviceCard(c ServiceCard, loc *time.Location) {
-	<a href={ templ.URL("/dashboard/services/" + c.Name) } class="block bg-white shadow rounded-lg p-5 hover:shadow-md transition border border-transparent hover:border-blue-200">
+	<a href={ templ.URL("/dashboard/services/" + c.Name) } class="block bg-gray-800 shadow rounded-lg p-5 hover:shadow-lg hover:bg-gray-750 transition border border-gray-700 hover:border-blue-500">
 		<div class="flex items-start justify-between">
 			<div class="space-y-1">
 				<div class="flex items-center space-x-2">
-					<h3 class="text-lg font-semibold text-gray-900">{ c.Name }</h3>
+					<h3 class="text-lg font-semibold text-gray-100">{ c.Name }</h3>
 					if c.Orphan {
-						<span class="text-xs px-2 py-0.5 rounded bg-yellow-100 text-yellow-800">huérfano</span>
+						<span class="text-xs px-2 py-0.5 rounded bg-yellow-900/50 text-yellow-300 border border-yellow-700">huérfano</span>
 					}
 				</div>
 				if c.BasePrefix != "" {
-					<p class="text-sm font-mono text-blue-700">{ c.BasePrefix }</p>
+					<p class="text-sm font-mono text-blue-400">{ c.BasePrefix }</p>
 				}
 				if c.Target != "" {
-					<p class="text-xs text-gray-500 break-all">→ { c.Target }</p>
+					<p class="text-xs text-gray-400 break-all">→ { c.Target }</p>
 				}
 			</div>
 			<div class="text-right">
-				<div class="text-2xl font-bold text-gray-900">{ fmt.Sprintf("%d", c.Count) }</div>
-				<div class="text-xs text-gray-500">requests</div>
+				<div class="text-2xl font-bold text-gray-100">{ fmt.Sprintf("%d", c.Count) }</div>
+				<div class="text-xs text-gray-400">requests</div>
 			</div>
 		</div>
 		<div class="mt-3 text-xs text-gray-500">

--- a/internal/dashboard/views/dashboard_templ.go
+++ b/internal/dashboard/views/dashboard_templ.go
@@ -46,7 +46,7 @@ func Dashboard(cards []ServiceCard, loc *time.Location) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-8\"><header class=\"flex items-baseline justify-between\"><div class=\"flex items-baseline\"><h1 class=\"text-3xl font-bold text-gray-900\">Golden Gate</h1><a href=\"/dashboard/config\" class=\"text-sm text-gray-600 hover:text-gray-900 ml-4\">⚙ Editar config</a></div><span class=\"text-sm text-gray-500\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-8\"><header class=\"flex items-baseline justify-between\"><div class=\"flex items-baseline\"><h1 class=\"text-3xl font-bold text-white\">Golden Gate</h1><a href=\"/dashboard/config\" class=\"text-sm text-gray-400 hover:text-gray-200 ml-4\">⚙ Editar config</a></div><span class=\"text-sm text-gray-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -59,12 +59,12 @@ func Dashboard(cards []ServiceCard, loc *time.Location) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></header><section class=\"space-y-4\"><h2 class=\"text-xl font-semibold text-gray-800\">Servicios configurados</h2>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></header><section class=\"space-y-4\"><h2 class=\"text-xl font-semibold text-gray-200\">Servicios configurados</h2>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(cards) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"text-gray-500\">No hay servicios configurados. Editá <code>configs/service.json</code> para agregar uno.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"text-gray-400\">No hay servicios configurados. Editá <code class=\"bg-gray-800 px-1.5 py-0.5 rounded text-gray-300\">configs/service.json</code> para agregar uno.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -132,7 +132,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" class=\"block bg-white shadow rounded-lg p-5 hover:shadow-md transition border border-transparent hover:border-blue-200\"><div class=\"flex items-start justify-between\"><div class=\"space-y-1\"><div class=\"flex items-center space-x-2\"><h3 class=\"text-lg font-semibold text-gray-900\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" class=\"block bg-gray-800 shadow rounded-lg p-5 hover:shadow-lg hover:bg-gray-750 transition border border-gray-700 hover:border-blue-500\"><div class=\"flex items-start justify-between\"><div class=\"space-y-1\"><div class=\"flex items-center space-x-2\"><h3 class=\"text-lg font-semibold text-gray-100\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -150,7 +150,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if c.Orphan {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span class=\"text-xs px-2 py-0.5 rounded bg-yellow-100 text-yellow-800\">huérfano</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span class=\"text-xs px-2 py-0.5 rounded bg-yellow-900/50 text-yellow-300 border border-yellow-700\">huérfano</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -160,7 +160,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if c.BasePrefix != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"text-sm font-mono text-blue-700\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<p class=\"text-sm font-mono text-blue-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -179,7 +179,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 			}
 		}
 		if c.Target != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<p class=\"text-xs text-gray-500 break-all\">→ ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<p class=\"text-xs text-gray-400 break-all\">→ ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -197,7 +197,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"text-right\"><div class=\"text-2xl font-bold text-gray-900\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div class=\"text-right\"><div class=\"text-2xl font-bold text-gray-100\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -210,7 +210,7 @@ func serviceCard(c ServiceCard, loc *time.Location) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"text-xs text-gray-500\">requests</div></div></div><div class=\"mt-3 text-xs text-gray-500\">Último: ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div class=\"text-xs text-gray-400\">requests</div></div></div><div class=\"mt-3 text-xs text-gray-500\">Último: ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/dashboard/views/editor.templ
+++ b/internal/dashboard/views/editor.templ
@@ -6,37 +6,37 @@ templ Editor(v EditorView) {
 	@Layout("Golden Gate — Editar service.json") {
 		<div class="space-y-6">
 			<div class="flex items-center justify-between">
-				<a href="/dashboard" class="text-sm text-blue-600 hover:underline">← Volver al dashboard</a>
-				<h1 class="text-2xl font-bold text-gray-900">Editar service.json</h1>
+				<a href="/dashboard" class="text-sm text-blue-400 hover:underline">← Volver al dashboard</a>
+				<h1 class="text-2xl font-bold text-white">Editar service.json</h1>
 			</div>
 
-			<div class="bg-white shadow rounded-lg p-4 text-sm text-gray-700 space-y-1">
+			<div class="bg-gray-800 shadow rounded-lg p-4 text-sm text-gray-300 space-y-1 border border-gray-700">
 				<div>
-					<span class="font-semibold">Archivo:</span>
-					<span class="font-mono break-all">{ v.Path }</span>
+					<span class="font-semibold text-gray-200">Archivo:</span>
+					<span class="font-mono break-all text-gray-400">{ v.Path }</span>
 				</div>
 				<div>
-					<span class="font-semibold">Servicios activos:</span>
+					<span class="font-semibold text-gray-200">Servicios activos:</span>
 					<span>{ fmt.Sprintf("%d", v.ServiceCount) }</span>
 				</div>
 			</div>
 
 			if v.Success {
-				<div class="bg-green-50 border border-green-200 text-green-800 p-3 rounded">
+				<div class="bg-green-900/40 border border-green-700 text-green-300 p-3 rounded">
 					Configuración guardada. Hot reload aplicado.
 				</div>
 			}
 
 			if v.Error != "" {
-				<div class="bg-red-50 border border-red-200 text-red-800 p-3 rounded whitespace-pre-wrap break-all">
+				<div class="bg-red-900/40 border border-red-700 text-red-300 p-3 rounded whitespace-pre-wrap break-all">
 					{ v.Error }
 				</div>
 			}
 
 			<form method="POST" action="/dashboard/config" class="space-y-4">
-				<textarea name="content" rows="24" spellcheck="false" class="w-full font-mono text-sm p-3 border rounded">{ v.Content }</textarea>
+				<textarea name="content" rows="24" spellcheck="false" class="w-full font-mono text-sm p-3 bg-gray-900 border border-gray-600 text-gray-200 rounded focus:border-blue-500 focus:ring-blue-500">{ v.Content }</textarea>
 				<div>
-					<button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+					<button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-500 transition">
 						Guardar y aplicar
 					</button>
 				</div>

--- a/internal/dashboard/views/editor_templ.go
+++ b/internal/dashboard/views/editor_templ.go
@@ -43,20 +43,20 @@ func Editor(v EditorView) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-6\"><div class=\"flex items-center justify-between\"><a href=\"/dashboard\" class=\"text-sm text-blue-600 hover:underline\">← Volver al dashboard</a><h1 class=\"text-2xl font-bold text-gray-900\">Editar service.json</h1></div><div class=\"bg-white shadow rounded-lg p-4 text-sm text-gray-700 space-y-1\"><div><span class=\"font-semibold\">Archivo:</span> <span class=\"font-mono break-all\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-6\"><div class=\"flex items-center justify-between\"><a href=\"/dashboard\" class=\"text-sm text-blue-400 hover:underline\">← Volver al dashboard</a><h1 class=\"text-2xl font-bold text-white\">Editar service.json</h1></div><div class=\"bg-gray-800 shadow rounded-lg p-4 text-sm text-gray-300 space-y-1 border border-gray-700\"><div><span class=\"font-semibold text-gray-200\">Archivo:</span> <span class=\"font-mono break-all text-gray-400\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(v.Path)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/editor.templ`, Line: 16, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/editor.templ`, Line: 16, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></div><div><span class=\"font-semibold\">Servicios activos:</span> <span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></div><div><span class=\"font-semibold text-gray-200\">Servicios activos:</span> <span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -74,13 +74,13 @@ func Editor(v EditorView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if v.Success {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"bg-green-50 border border-green-200 text-green-800 p-3 rounded\">Configuración guardada. Hot reload aplicado.</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"bg-green-900/40 border border-green-700 text-green-300 p-3 rounded\">Configuración guardada. Hot reload aplicado.</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if v.Error != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"bg-red-50 border border-red-200 text-red-800 p-3 rounded whitespace-pre-wrap break-all\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"bg-red-900/40 border border-red-700 text-red-300 p-3 rounded whitespace-pre-wrap break-all\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -98,20 +98,20 @@ func Editor(v EditorView) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<form method=\"POST\" action=\"/dashboard/config\" class=\"space-y-4\"><textarea name=\"content\" rows=\"24\" spellcheck=\"false\" class=\"w-full font-mono text-sm p-3 border rounded\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<form method=\"POST\" action=\"/dashboard/config\" class=\"space-y-4\"><textarea name=\"content\" rows=\"24\" spellcheck=\"false\" class=\"w-full font-mono text-sm p-3 bg-gray-900 border border-gray-600 text-gray-200 rounded focus:border-blue-500 focus:ring-blue-500\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(v.Content)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/editor.templ`, Line: 37, Col: 121}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/editor.templ`, Line: 37, Col: 205}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</textarea><div><button type=\"submit\" class=\"bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700\">Guardar y aplicar</button></div></form></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</textarea><div><button type=\"submit\" class=\"bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-500 transition\">Guardar y aplicar</button></div></form></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/internal/dashboard/views/explore.templ
+++ b/internal/dashboard/views/explore.templ
@@ -13,39 +13,39 @@ templ Explore(v ExploreView) {
 	@Layout("Golden Gate — " + v.ServiceName) {
 		<div class="space-y-6">
 			<div class="flex items-center justify-between">
-				<a href="/dashboard" class="text-sm text-blue-600 hover:underline">← Volver al dashboard</a>
-				<span class="text-xs text-gray-500">TZ: { v.Location.String() }</span>
+				<a href="/dashboard" class="text-sm text-blue-400 hover:underline">← Volver al dashboard</a>
+				<span class="text-xs text-gray-400">TZ: { v.Location.String() }</span>
 			</div>
 
-			<header class="bg-white shadow rounded-lg p-5">
+			<header class="bg-gray-800 shadow rounded-lg p-5 border border-gray-700">
 				<div class="flex items-baseline justify-between flex-wrap gap-2">
 					<div>
-						<h1 class="text-2xl font-bold text-gray-900">{ v.ServiceName }</h1>
+						<h1 class="text-2xl font-bold text-white">{ v.ServiceName }</h1>
 						if v.BasePrefix != "" {
-							<p class="text-sm font-mono text-blue-700">{ v.BasePrefix }</p>
+							<p class="text-sm font-mono text-blue-400">{ v.BasePrefix }</p>
 						}
 						if v.Target != "" {
-							<p class="text-xs text-gray-500 break-all">→ { v.Target }</p>
+							<p class="text-xs text-gray-400 break-all">→ { v.Target }</p>
 						}
 					</div>
 					<div class="text-right">
-						<div class="text-3xl font-bold text-gray-900">{ fmt.Sprintf("%d", v.Count) }</div>
-						<div class="text-xs text-gray-500">requests en rango</div>
+						<div class="text-3xl font-bold text-gray-100">{ fmt.Sprintf("%d", v.Count) }</div>
+						<div class="text-xs text-gray-400">requests en rango</div>
 					</div>
 				</div>
 			</header>
 
-			<form method="get" class="bg-white shadow rounded-lg p-4 grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
+			<form method="get" class="bg-gray-800 shadow rounded-lg p-4 grid grid-cols-1 md:grid-cols-3 gap-3 items-end border border-gray-700">
 				<label class="text-sm">
-					<span class="block text-gray-700 mb-1">Desde</span>
-					<input type="datetime-local" name="from" value={ formatLocalInput(v.From, v.Location) } class="w-full border rounded px-2 py-1"/>
+					<span class="block text-gray-300 mb-1">Desde</span>
+					<input type="datetime-local" name="from" value={ formatLocalInput(v.From, v.Location) } class="w-full bg-gray-900 border-gray-600 text-gray-200 rounded px-2 py-1 focus:border-blue-500 focus:ring-blue-500"/>
 				</label>
 				<label class="text-sm">
-					<span class="block text-gray-700 mb-1">Hasta</span>
-					<input type="datetime-local" name="to" value={ formatLocalInput(v.To, v.Location) } class="w-full border rounded px-2 py-1"/>
+					<span class="block text-gray-300 mb-1">Hasta</span>
+					<input type="datetime-local" name="to" value={ formatLocalInput(v.To, v.Location) } class="w-full bg-gray-900 border-gray-600 text-gray-200 rounded px-2 py-1 focus:border-blue-500 focus:ring-blue-500"/>
 				</label>
 				<div>
-					<button type="submit" class="w-full md:w-auto bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 rounded">
+					<button type="submit" class="w-full md:w-auto bg-blue-600 hover:bg-blue-500 text-white px-4 py-1.5 rounded transition">
 						Filtrar
 					</button>
 				</div>
@@ -53,7 +53,7 @@ templ Explore(v ExploreView) {
 
 			<section>
 				if len(v.Requests) == 0 {
-					<div class="bg-white shadow rounded-lg p-6 text-center text-gray-500">
+					<div class="bg-gray-800 shadow rounded-lg p-6 text-center text-gray-400 border border-gray-700">
 						No hay requests en el rango seleccionado.
 					</div>
 				} else {
@@ -68,13 +68,13 @@ templ Explore(v ExploreView) {
 			if v.HasNext || v.Page > 1 {
 				<nav class="flex items-center justify-between">
 					if v.Page > 1 {
-						<a href={ templ.URL(pageLink(v, v.Page-1)) } class="text-sm text-blue-600 hover:underline">← Anterior</a>
+						<a href={ templ.URL(pageLink(v, v.Page-1)) } class="text-sm text-blue-400 hover:underline">← Anterior</a>
 					} else {
 						<span></span>
 					}
-					<span class="text-xs text-gray-500">Página { fmt.Sprintf("%d", v.Page) }</span>
+					<span class="text-xs text-gray-400">Página { fmt.Sprintf("%d", v.Page) }</span>
 					if v.HasNext {
-						<a href={ templ.URL(pageLink(v, v.Page+1)) } class="text-sm text-blue-600 hover:underline">Siguiente →</a>
+						<a href={ templ.URL(pageLink(v, v.Page+1)) } class="text-sm text-blue-400 hover:underline">Siguiente →</a>
 					} else {
 						<span></span>
 					}
@@ -85,19 +85,19 @@ templ Explore(v ExploreView) {
 }
 
 templ requestDetail(req *models.RequestLog, loc *time.Location) {
-	<div id={ "request-" + fmt.Sprintf("%d", req.ID) } class="bg-white shadow rounded-lg p-5 space-y-4">
-		<div class="flex items-center justify-between border-b pb-3">
+	<div id={ "request-" + fmt.Sprintf("%d", req.ID) } class="bg-gray-800 shadow rounded-lg p-5 space-y-4 border border-gray-700">
+		<div class="flex items-center justify-between border-b border-gray-700 pb-3">
 			<div class="space-y-1">
 				<div class="flex items-center space-x-2 flex-wrap">
-					<span class="px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm font-medium">{ req.Method }</span>
+					<span class="px-2 py-1 bg-blue-900/50 text-blue-300 rounded text-sm font-medium border border-blue-800">{ req.Method }</span>
 					if req.Response != nil {
-						<span class={ "px-2 py-1 rounded text-sm font-medium", statusClass(req.Response.StatusCode) }>
+						<span class={ "px-2 py-1 rounded text-sm font-medium border", statusClass(req.Response.StatusCode) }>
 							{ fmt.Sprintf("%d", req.Response.StatusCode) }
 						</span>
 					}
-					<span class="font-mono text-gray-700 text-sm break-all">{ req.URL }</span>
+					<span class="font-mono text-gray-300 text-sm break-all">{ req.URL }</span>
 				</div>
-				<div class="text-xs text-gray-500 space-x-3">
+				<div class="text-xs text-gray-400 space-x-3">
 					<span>{ formatTime(req.Timestamp, loc) }</span>
 					if req.DurationMs > 0 {
 						<span>{ fmt.Sprintf("%d ms", req.DurationMs) }</span>
@@ -108,43 +108,43 @@ templ requestDetail(req *models.RequestLog, loc *time.Location) {
 
 		<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 			<div class="space-y-3">
-				<h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Request</h3>
+				<h3 class="text-sm font-semibold text-gray-200 uppercase tracking-wide">Request</h3>
 
 				if len(req.Headers) > 0 {
-					<details class="bg-gray-50 rounded">
-						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">Headers</summary>
-						<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all">{ formatHeaders(req.Headers) }</pre>
+					<details class="bg-gray-900 rounded border border-gray-700">
+						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Headers</summary>
+						<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300">{ formatHeaders(req.Headers) }</pre>
 					</details>
 				}
 
 				if len(req.Query) > 0 {
-					<details class="bg-gray-50 rounded">
-						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">Query params</summary>
-						<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all">{ formatQueryParams(req.Query) }</pre>
+					<details class="bg-gray-900 rounded border border-gray-700">
+						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Query params</summary>
+						<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300">{ formatQueryParams(req.Query) }</pre>
 					</details>
 				}
 
 				if len(req.Body) > 0 {
-					<details open class="bg-gray-50 rounded">
-						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">Body</summary>
-						<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all">{ formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated) }</pre>
+					<details open class="bg-gray-900 rounded border border-gray-700">
+						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Body</summary>
+						<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300">{ formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated) }</pre>
 					</details>
 				}
 			</div>
 
 			<div class="space-y-3">
-				<h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide">Response</h3>
+				<h3 class="text-sm font-semibold text-gray-200 uppercase tracking-wide">Response</h3>
 				if req.Response != nil {
 					if len(req.Response.Headers) > 0 {
-						<details class="bg-gray-50 rounded">
-							<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">Headers</summary>
-							<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all">{ formatHeaders(req.Response.Headers) }</pre>
+						<details class="bg-gray-900 rounded border border-gray-700">
+							<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Headers</summary>
+							<pre class="text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300">{ formatHeaders(req.Response.Headers) }</pre>
 						</details>
 					}
 					if len(req.Response.Body) > 0 {
-						<details open class="bg-gray-50 rounded">
-							<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">Body</summary>
-							<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all">{ formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated) }</pre>
+						<details open class="bg-gray-900 rounded border border-gray-700">
+							<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Body</summary>
+							<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300">{ formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated) }</pre>
 						</details>
 					}
 				} else {
@@ -153,9 +153,9 @@ templ requestDetail(req *models.RequestLog, loc *time.Location) {
 			</div>
 		</div>
 
-		<details class="bg-gray-50 rounded">
-			<summary class="cursor-pointer px-3 py-2 text-sm text-gray-700">curl</summary>
-			<pre class="text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all">{ buildCurlCommand(req) }</pre>
+		<details class="bg-gray-900 rounded border border-gray-700">
+			<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">curl</summary>
+			<pre class="text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all text-gray-300">{ buildCurlCommand(req) }</pre>
 		</details>
 	</div>
 }

--- a/internal/dashboard/views/explore_templ.go
+++ b/internal/dashboard/views/explore_templ.go
@@ -50,7 +50,7 @@ func Explore(v ExploreView) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-6\"><div class=\"flex items-center justify-between\"><a href=\"/dashboard\" class=\"text-sm text-blue-600 hover:underline\">← Volver al dashboard</a> <span class=\"text-xs text-gray-500\">TZ: ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-6\"><div class=\"flex items-center justify-between\"><a href=\"/dashboard\" class=\"text-sm text-blue-400 hover:underline\">← Volver al dashboard</a> <span class=\"text-xs text-gray-400\">TZ: ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -63,14 +63,14 @@ func Explore(v ExploreView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></div><header class=\"bg-white shadow rounded-lg p-5\"><div class=\"flex items-baseline justify-between flex-wrap gap-2\"><div><h1 class=\"text-2xl font-bold text-gray-900\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</span></div><header class=\"bg-gray-800 shadow rounded-lg p-5 border border-gray-700\"><div class=\"flex items-baseline justify-between flex-wrap gap-2\"><div><h1 class=\"text-2xl font-bold text-white\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(v.ServiceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 23, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 23, Col: 63}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -81,7 +81,7 @@ func Explore(v ExploreView) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if v.BasePrefix != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<p class=\"text-sm font-mono text-blue-700\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<p class=\"text-sm font-mono text-blue-400\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -100,7 +100,7 @@ func Explore(v ExploreView) templ.Component {
 				}
 			}
 			if v.Target != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<p class=\"text-xs text-gray-500 break-all\">→ ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<p class=\"text-xs text-gray-400 break-all\">→ ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -118,7 +118,7 @@ func Explore(v ExploreView) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div class=\"text-right\"><div class=\"text-3xl font-bold text-gray-900\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div class=\"text-right\"><div class=\"text-3xl font-bold text-gray-100\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -131,7 +131,7 @@ func Explore(v ExploreView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div class=\"text-xs text-gray-500\">requests en rango</div></div></div></header><form method=\"get\" class=\"bg-white shadow rounded-lg p-4 grid grid-cols-1 md:grid-cols-3 gap-3 items-end\"><label class=\"text-sm\"><span class=\"block text-gray-700 mb-1\">Desde</span> <input type=\"datetime-local\" name=\"from\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div class=\"text-xs text-gray-400\">requests en rango</div></div></div></header><form method=\"get\" class=\"bg-gray-800 shadow rounded-lg p-4 grid grid-cols-1 md:grid-cols-3 gap-3 items-end border border-gray-700\"><label class=\"text-sm\"><span class=\"block text-gray-300 mb-1\">Desde</span> <input type=\"datetime-local\" name=\"from\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -144,7 +144,7 @@ func Explore(v ExploreView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" class=\"w-full border rounded px-2 py-1\"></label> <label class=\"text-sm\"><span class=\"block text-gray-700 mb-1\">Hasta</span> <input type=\"datetime-local\" name=\"to\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" class=\"w-full bg-gray-900 border-gray-600 text-gray-200 rounded px-2 py-1 focus:border-blue-500 focus:ring-blue-500\"></label> <label class=\"text-sm\"><span class=\"block text-gray-300 mb-1\">Hasta</span> <input type=\"datetime-local\" name=\"to\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -157,12 +157,12 @@ func Explore(v ExploreView) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"w-full border rounded px-2 py-1\"></label><div><button type=\"submit\" class=\"w-full md:w-auto bg-blue-600 hover:bg-blue-700 text-white px-4 py-1.5 rounded\">Filtrar</button></div></form><section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" class=\"w-full bg-gray-900 border-gray-600 text-gray-200 rounded px-2 py-1 focus:border-blue-500 focus:ring-blue-500\"></label><div><button type=\"submit\" class=\"w-full md:w-auto bg-blue-600 hover:bg-blue-500 text-white px-4 py-1.5 rounded transition\">Filtrar</button></div></form><section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if len(v.Requests) == 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"bg-white shadow rounded-lg p-6 text-center text-gray-500\">No hay requests en el rango seleccionado.</div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"bg-gray-800 shadow rounded-lg p-6 text-center text-gray-400 border border-gray-700\">No hay requests en el rango seleccionado.</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -205,7 +205,7 @@ func Explore(v ExploreView) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" class=\"text-sm text-blue-600 hover:underline\">← Anterior</a> ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" class=\"text-sm text-blue-400 hover:underline\">← Anterior</a> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -215,7 +215,7 @@ func Explore(v ExploreView) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"text-xs text-gray-500\">Página ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"text-xs text-gray-400\">Página ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -246,7 +246,7 @@ func Explore(v ExploreView) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" class=\"text-sm text-blue-600 hover:underline\">Siguiente →</a>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" class=\"text-sm text-blue-400 hover:underline\">Siguiente →</a>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -309,14 +309,14 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" class=\"bg-white shadow rounded-lg p-5 space-y-4\"><div class=\"flex items-center justify-between border-b pb-3\"><div class=\"space-y-1\"><div class=\"flex items-center space-x-2 flex-wrap\"><span class=\"px-2 py-1 bg-blue-100 text-blue-800 rounded text-sm font-medium\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" class=\"bg-gray-800 shadow rounded-lg p-5 space-y-4 border border-gray-700\"><div class=\"flex items-center justify-between border-b border-gray-700 pb-3\"><div class=\"space-y-1\"><div class=\"flex items-center space-x-2 flex-wrap\"><span class=\"px-2 py-1 bg-blue-900/50 text-blue-300 rounded text-sm font-medium border border-blue-800\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(req.Method)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 92, Col: 95}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 92, Col: 121}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -327,7 +327,7 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if req.Response != nil {
-			var templ_7745c5c3_Var16 = []any{"px-2 py-1 rounded text-sm font-medium", statusClass(req.Response.StatusCode)}
+			var templ_7745c5c3_Var16 = []any{"px-2 py-1 rounded text-sm font-medium border", statusClass(req.Response.StatusCode)}
 			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var16...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -363,7 +363,7 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<span class=\"font-mono text-gray-700 text-sm break-all\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<span class=\"font-mono text-gray-300 text-sm break-all\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -376,7 +376,7 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span></div><div class=\"text-xs text-gray-500 space-x-3\"><span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span></div><div class=\"text-xs text-gray-400 space-x-3\"><span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -412,19 +412,19 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div><div class=\"grid grid-cols-1 lg:grid-cols-2 gap-6\"><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-900 uppercase tracking-wide\">Request</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div><div class=\"grid grid-cols-1 lg:grid-cols-2 gap-6\"><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-200 uppercase tracking-wide\">Request</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(req.Headers) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<details class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(formatHeaders(req.Headers))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 116, Col: 122}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 116, Col: 136}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -436,14 +436,14 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 			}
 		}
 		if len(req.Query) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<details class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">Query params</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Query params</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(formatQueryParams(req.Query))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 123, Col: 124}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 123, Col: 138}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -455,14 +455,14 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 			}
 		}
 		if len(req.Body) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<details open class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 130, Col: 168}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 130, Col: 182}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -473,20 +473,20 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-900 uppercase tracking-wide\">Response</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-200 uppercase tracking-wide\">Response</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if req.Response != nil {
 			if len(req.Response.Headers) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<details class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(formatHeaders(req.Response.Headers))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 141, Col: 132}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 141, Col: 146}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -502,14 +502,14 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if len(req.Response.Body) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<details open class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var26 string
 				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 147, Col: 196}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 147, Col: 210}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 				if templ_7745c5c3_Err != nil {
@@ -526,14 +526,14 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div></div><details class=\"bg-gray-50 rounded\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-700\">curl</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div></div><details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">curl</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all text-gray-300\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(buildCurlCommand(req))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 158, Col: 114}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 158, Col: 128}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {

--- a/internal/dashboard/views/layout.templ
+++ b/internal/dashboard/views/layout.templ
@@ -10,7 +10,7 @@ templ Layout(title string) {
 			<script src="https://unpkg.com/htmx.org@1.9.10"></script>
 			<script src="https://cdn.tailwindcss.com"></script>
 		</head>
-		<body class="bg-gray-100">
+		<body class="bg-gray-950 text-gray-200 min-h-screen">
 			<div class="container mx-auto px-4 py-8">
 				{ children... }
 			</div>

--- a/internal/dashboard/views/layout_templ.go
+++ b/internal/dashboard/views/layout_templ.go
@@ -42,7 +42,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><script src=\"https://unpkg.com/htmx.org@1.9.10\"></script><script src=\"https://cdn.tailwindcss.com\"></script></head><body class=\"bg-gray-100\"><div class=\"container mx-auto px-4 py-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><script src=\"https://unpkg.com/htmx.org@1.9.10\"></script><script src=\"https://cdn.tailwindcss.com\"></script></head><body class=\"bg-gray-950 text-gray-200 min-h-screen\"><div class=\"container mx-auto px-4 py-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/dashboard/views/types.go
+++ b/internal/dashboard/views/types.go
@@ -173,14 +173,14 @@ func escapeSingleQuotes(s string) string {
 func statusClass(code int) string {
 	switch {
 	case code == 0:
-		return "bg-gray-100 text-gray-700"
+		return "bg-gray-700 text-gray-300 border-gray-600"
 	case code >= 200 && code < 300:
-		return "bg-green-100 text-green-800"
+		return "bg-green-900/50 text-green-300 border-green-700"
 	case code >= 300 && code < 400:
-		return "bg-blue-100 text-blue-800"
+		return "bg-blue-900/50 text-blue-300 border-blue-700"
 	case code >= 400 && code < 500:
-		return "bg-yellow-100 text-yellow-800"
+		return "bg-yellow-900/50 text-yellow-300 border-yellow-700"
 	default:
-		return "bg-red-100 text-red-800"
+		return "bg-red-900/50 text-red-300 border-red-700"
 	}
 }


### PR DESCRIPTION
## Qué cambia

Aplica un dark theme completo al dashboard de Golden Gate.

### Cambios

- **`layout.templ`** — fondo `bg-gray-950`, texto `text-gray-200`
- **`dashboard.templ`** — cards `bg-gray-800`, bordes `border-gray-700`, hover `border-blue-500`, títulos `text-white`
- **`explore.templ`** — header/form/detalles: inputs `bg-gray-900`, code blocks `bg-gray-900`, método badge `bg-blue-900/50`
- **`editor.templ`** — textarea `bg-gray-900`, alertas translúcidas, info card `bg-gray-800`
- **`types.go`** — función `statusClass` con colores dark (`900/50` + borders)

### Paleta

| Elemento | Light | Dark |
|---|---|---|
| Fondo página | gray-100 | gray-950 |
| Cards | white | gray-800 |
| Inputs/code | gray-50 | gray-900 |
| Texto principal | gray-900 | gray-100 / white |
| Links | blue-600 | blue-400 |
| Bordes | gray-200 | gray-700 |