### PR TITLE
feat: JSON syntax highlighting in request/response bodies

### DIFF
--- a/internal/dashboard/views/explore.templ
+++ b/internal/dashboard/views/explore.templ
@@ -127,7 +127,7 @@ templ requestDetail(req *models.RequestLog, loc *time.Location) {
 				if len(req.Body) > 0 {
 					<details open class="bg-gray-900 rounded border border-gray-700">
 						<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Body</summary>
-						<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300">{ formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated) }</pre>
+						<pre data-content-type={ contentTypeOf(req.Headers) } class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300"><code>{ formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated) }</code></pre>
 					</details>
 				}
 			</div>
@@ -144,7 +144,7 @@ templ requestDetail(req *models.RequestLog, loc *time.Location) {
 					if len(req.Response.Body) > 0 {
 						<details open class="bg-gray-900 rounded border border-gray-700">
 							<summary class="cursor-pointer px-3 py-2 text-sm text-gray-300">Body</summary>
-							<pre class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300">{ formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated) }</pre>
+							<pre data-content-type={ contentTypeOf(req.Response.Headers) } class="text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300"><code>{ formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated) }</code></pre>
 						</details>
 					}
 				} else {

--- a/internal/dashboard/views/explore_templ.go
+++ b/internal/dashboard/views/explore_templ.go
@@ -455,91 +455,117 @@ func requestDetail(req *models.RequestLog, loc *time.Location) templ.Component {
 			}
 		}
 		if len(req.Body) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre data-content-type=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated))
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(contentTypeOf(req.Headers))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 130, Col: 182}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 130, Col: 57}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</pre></details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\"><code>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Body, contentTypeOf(req.Headers), req.BodyTruncated))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 130, Col: 237}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</code></pre></details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-200 uppercase tracking-wide\">Response</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</div><div class=\"space-y-3\"><h3 class=\"text-sm font-semibold text-gray-200 uppercase tracking-wide\">Response</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if req.Response != nil {
 			if len(req.Response.Headers) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var25 string
-				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(formatHeaders(req.Response.Headers))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 141, Col: 146}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</pre></details>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if len(req.Response.Body) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Headers</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-64 whitespace-pre-wrap break-all text-gray-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var26 string
-				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated))
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(formatHeaders(req.Response.Headers))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 147, Col: 210}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 141, Col: 146}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</pre></details>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</pre></details>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if len(req.Response.Body) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<details open class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">Body</summary><pre data-content-type=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var27 string
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(contentTypeOf(req.Response.Headers))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 147, Col: 67}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" class=\"text-xs font-mono p-3 overflow-auto max-h-96 whitespace-pre-wrap break-all text-gray-300\"><code>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var28 string
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(formatBodySmart(req.Response.Body, contentTypeOf(req.Response.Headers), req.Response.BodyTruncated))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 147, Col: 274}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</code></pre></details>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<p class=\"text-xs text-gray-500\">Sin response registrada (request en vuelo o falló antes de upstream).</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<p class=\"text-xs text-gray-500\">Sin response registrada (request en vuelo o falló antes de upstream).</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div></div><details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">curl</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all text-gray-300\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</div></div><details class=\"bg-gray-900 rounded border border-gray-700\"><summary class=\"cursor-pointer px-3 py-2 text-sm text-gray-300\">curl</summary><pre class=\"text-xs font-mono p-3 overflow-auto max-h-48 whitespace-pre-wrap break-all text-gray-300\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(buildCurlCommand(req))
+		var templ_7745c5c3_Var29 string
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(buildCurlCommand(req))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/dashboard/views/explore.templ`, Line: 158, Col: 128}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</pre></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</pre></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/dashboard/views/layout.templ
+++ b/internal/dashboard/views/layout.templ
@@ -9,11 +9,42 @@ templ Layout(title string) {
 			<title>{ title }</title>
 			<script src="https://unpkg.com/htmx.org@1.9.10"></script>
 			<script src="https://cdn.tailwindcss.com"></script>
+			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/atom-one-dark.min.css"/>
+			<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
 		</head>
 		<body class="bg-gray-950 text-gray-200 min-h-screen">
 			<div class="container mx-auto px-4 py-8">
 				{ children... }
 			</div>
+			<script>
+				(function() {
+					function isJSON(text) {
+						var t = text.trim();
+						if (!t.startsWith('{') && !t.startsWith('[')) return false;
+						try { JSON.parse(t); return true; } catch(e) { return false; }
+					}
+
+					function highlightCode() {
+						document.querySelectorAll('pre[data-content-type]').forEach(function(pre) {
+							var ct = pre.getAttribute('data-content-type') || '';
+							var code = pre.querySelector('code');
+							if (!code) return;
+
+							if (ct.includes('json')) {
+								code.className = 'language-json';
+							} else if (ct.includes('html') || ct.includes('xml')) {
+								code.className = 'language-xml';
+							} else if (isJSON(code.textContent)) {
+								code.className = 'language-json';
+							}
+						});
+						hljs.highlightAll();
+					}
+
+					highlightCode();
+					document.body.addEventListener('htmx:afterSettle', highlightCode);
+				})();
+			</script>
 		</body>
 	</html>
-} 
+}

--- a/internal/dashboard/views/layout_templ.go
+++ b/internal/dashboard/views/layout_templ.go
@@ -42,7 +42,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><script src=\"https://unpkg.com/htmx.org@1.9.10\"></script><script src=\"https://cdn.tailwindcss.com\"></script></head><body class=\"bg-gray-950 text-gray-200 min-h-screen\"><div class=\"container mx-auto px-4 py-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><script src=\"https://unpkg.com/htmx.org@1.9.10\"></script><script src=\"https://cdn.tailwindcss.com\"></script><link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/atom-one-dark.min.css\"><script src=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js\"></script></head><body class=\"bg-gray-950 text-gray-200 min-h-screen\"><div class=\"container mx-auto px-4 py-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -50,7 +50,7 @@ func Layout(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><script>\n\t\t\t\t(function() {\n\t\t\t\t\tfunction isJSON(text) {\n\t\t\t\t\t\tvar t = text.trim();\n\t\t\t\t\t\tif (!t.startsWith('{') && !t.startsWith('[')) return false;\n\t\t\t\t\t\ttry { JSON.parse(t); return true; } catch(e) { return false; }\n\t\t\t\t\t}\n\n\t\t\t\t\tfunction highlightCode() {\n\t\t\t\t\t\tdocument.querySelectorAll('pre[data-content-type]').forEach(function(pre) {\n\t\t\t\t\t\t\tvar ct = pre.getAttribute('data-content-type') || '';\n\t\t\t\t\t\t\tvar code = pre.querySelector('code');\n\t\t\t\t\t\t\tif (!code) return;\n\n\t\t\t\t\t\t\tif (ct.includes('json')) {\n\t\t\t\t\t\t\t\tcode.className = 'language-json';\n\t\t\t\t\t\t\t} else if (ct.includes('html') || ct.includes('xml')) {\n\t\t\t\t\t\t\t\tcode.className = 'language-xml';\n\t\t\t\t\t\t\t} else if (isJSON(code.textContent)) {\n\t\t\t\t\t\t\t\tcode.className = 'language-json';\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t\thljs.highlightAll();\n\t\t\t\t\t}\n\n\t\t\t\t\thighlightCode();\n\t\t\t\t\tdocument.body.addEventListener('htmx:afterSettle', highlightCode);\n\t\t\t\t})();\n\t\t\t</script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Qué cambia

Agrega **syntax highlighting** a los cuerpos JSON de request/response en el dashboard.

### Detalles

- **highlight.js** (v11.11.1, tema `atom-one-dark`) cargado desde CDN en el layout
- Los `<pre>` de body ahora incluyen `<code>` interno + atributo `data-content-type`
- **Detección de lenguaje:**
  1. Vía header `Content-Type` → `application/json` → `language-json`
  2. Fallback por contenido → intenta `JSON.parse()`, si pasa → `language-json`
  3. `text/html` / `text/xml` → `language-xml`
- **HTMX-aware:** el script se re-ejecuta en `htmx:afterSettle` (paginación, filtros)

### Archivos modificados
- `layout.templ` — CDN links + script de highlighting
- `explore.templ` — wrappers `<pre><code>` + `data-content-type` en bodies
- `layout_templ.go`, `explore_templ.go` — regenerados

### Preview
Los bloques JSON en request/response ahora se ven con colores (keys, strings, numbers, booleans) en vez de texto plano gris.